### PR TITLE
Feature: Download avatar as PNG image - Solves issue #7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,16 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.13.8.tgz",
+      "integrity": "sha512-iaInhjy1BbDnqc7pZiIXAfWvBnczgWobHceR4Wkhs5tWZG8aIazBYH0Vo73lixecHKh3Vy9yqbQBqVDrmcVDlQ==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@hapi/address": {
       "version": "2.1.4",
       "resolved": "https://registry.npm.taobao.org/@hapi/address/download/@hapi/address-2.1.4.tgz",
@@ -173,6 +183,12 @@
       "version": "1.5.2",
       "resolved": "https://registry.npm.taobao.org/@types/q/download/@types/q-1.5.2.tgz",
       "integrity": "sha1-aQoUdbhPKohP0HzXl8APXzE1bqg=",
+      "dev": true
+    },
+    "@types/raf": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.0.tgz",
+      "integrity": "sha512-taW5/WYqo36N7V39oYyHP9Ipfd5pNFvGTIQsNGj86xV88YQ7GnI30/yMfKDF7Zgin0m3e+ikX88FvImnK4RjGw==",
       "dev": true
     },
     "@vue/cli-overlay": {
@@ -1403,6 +1419,20 @@
       "integrity": "sha1-uNIkkU4s1/UHCFWD1OOBRMZSvOQ=",
       "dev": true
     },
+    "canvg": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.7.tgz",
+      "integrity": "sha512-4sq6iL5Q4VOXS3PL1BapiXIZItpxYyANVzsAKpTPS5oq4u3SKbGfUcbZh2gdLCQ3jWpG/y5wRkMlBBAJhXeiZA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.9.6",
+        "@types/raf": "^3.4.0",
+        "raf": "^3.4.1",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^5.0.5"
+      }
+    },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.3.0",
       "resolved": "https://registry.npm.taobao.org/case-sensitive-paths-webpack-plugin/download/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
@@ -2060,6 +2090,12 @@
           "dev": true
         }
       }
+    },
+    "core-js-pure": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.9.0.tgz",
+      "integrity": "sha512-3pEcmMZC9Cq0D4ZBh3pe2HLtqxpGNJBLXF/kZ2YzK17RbKp94w0HFbdbSx8H8kAlZG5k76hvLrkPm57Uyef+kg==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -7509,6 +7545,15 @@
       "integrity": "sha1-YOWl/WSn+L+k0qsu1v30yFutFU4=",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npm.taobao.org/randombytes/download/randombytes-2.1.0.tgz",
@@ -7685,6 +7730,12 @@
           }
         }
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.2",
@@ -7910,6 +7961,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npm.taobao.org/rgba-regex/download/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=",
+      "dev": true
+    },
+    "rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0=",
       "dev": true
     },
     "rimraf": {
@@ -8749,6 +8806,12 @@
       "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
       "dev": true
     },
+    "stackblur-canvas": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.5.0.tgz",
+      "integrity": "sha512-EeNzTVfj+1In7aSLPKDD03F/ly4RxEuF/EX0YcOG0cKoPXs+SLZxDawQbexQDBzwROs4VKLWTOaZQlZkGBFEIQ==",
+      "dev": true
+    },
     "stackframe": {
       "version": "1.1.1",
       "resolved": "https://registry.npm.taobao.org/stackframe/download/stackframe-1.1.1.tgz",
@@ -8977,6 +9040,12 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svg-pathdata": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-5.0.5.tgz",
+      "integrity": "sha512-TAAvLNSE3fEhyl/Da19JWfMAdhSXTYeviXsLSoDT1UM76ADj5ndwAPX1FKQEgB/gFMPavOy6tOqfalXKUiXrow==",
+      "dev": true
     },
     "svgo": {
       "version": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "devDependencies": {
     "@vue/cli-service": "~4.2.0",
     "node-sass": "^4.12.0",
+    "canvg": "^3.0.7",
     "sass-loader": "^8.0.2",
     "vue-template-compiler": "^2.6.11"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,6 @@
 <template>
   <div id="app">
     <div id="avatar">
-      <SaveImage />
       <Accesories />
       <Clothes />
       <Eyebrows />
@@ -14,6 +13,7 @@
       <Tattoos />
     </div>
     <Footer />
+    <SaveImage/>
   </div>
 </template>
 
@@ -61,4 +61,5 @@ export default {
 @import "./assets/sass/responsive";
 @import "./assets/sass/avatar";
 @import "./assets/sass/footer";
+@import "./assets/sass/save_image"
 </style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="app">
     <div id="avatar">
+      <SaveImage />
       <Accesories />
       <Clothes />
       <Eyebrows />
@@ -32,6 +33,9 @@ import Tattoos     from './components/layout/tattoos'
 // import footer
 import Footer      from './components/footer'
 
+// import save Image
+import SaveImage   from './components/save_image'
+
 export default {
   name: 'App',
   components: {
@@ -45,7 +49,8 @@ export default {
     Mounths,
     SkinColor,
     Tattoos,
-    Footer
+    Footer,
+    SaveImage
   }
 }
 </script>

--- a/src/assets/sass/_avatar.scss
+++ b/src/assets/sass/_avatar.scss
@@ -22,7 +22,7 @@ img {
 	overflow: hidden;
   max-width: 800px;
   width: 100%;
-  height: 500px;
+  height: 580px;
   margin: 0 auto;
   box-shadow: 0 0 7px $shadow;
 	background: #fff;

--- a/src/assets/sass/_save_image.scss
+++ b/src/assets/sass/_save_image.scss
@@ -1,0 +1,36 @@
+/******************************
+******* SaveImage SCSS ********
+******************************/
+
+#save-image {
+  display: flex;
+  flex-direction: row;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 80px;
+  background: #e2e2e2;
+  bottom: 0;
+  z-index: 120;
+}
+
+.save-button {
+  transition-duration:0.3s;
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: none;
+  border-radius: 4px;
+  background-color: #c3c3c3;
+}
+
+.save-button:hover {
+  background-color: #00790d;
+  color: white;
+  cursor: pointer;
+}
+
+.save-button:focus {
+    outline: none;
+}

--- a/src/components/save_image.vue
+++ b/src/components/save_image.vue
@@ -1,0 +1,62 @@
+<template>
+  <button id="save" @click="saveImage">Download Avatar</button>
+</template>
+
+<script>
+import Canvg from 'canvg';
+
+export default {
+  name: 'SaveImage',
+  methods: {
+    async saveImage() {
+      const avatarDiv = document.querySelector('#avatar');
+
+      let combinedSvg = '<svg width="100%" height="100%">';
+
+      function addIfAvailable(element) {
+        if (element !== undefined && element !== null) {
+          combinedSvg = combinedSvg + element.outerHTML;
+        }
+      }
+      addIfAvailable(avatarDiv.querySelector('#skincolor').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#mouths').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#eyes').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#tattoos').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#facialhair2').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#eyebrows').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#accesories').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#clothes').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#hair').querySelector('.show'));
+      addIfAvailable(avatarDiv.querySelector('#glasses').querySelector('.show'));
+
+
+      combinedSvg = combinedSvg + '</svg>';
+      console.log(combinedSvg);
+
+      const canvas = document.createElement("canvas"); // create a canvas element
+      canvas.width = 420;
+      canvas.height = 420;
+      const ctx = canvas.getContext('2d');
+      const drawn = Canvg.fromString(ctx, combinedSvg, { ignoreClear: true, ignoreMouse: true });
+
+      await drawn.render();
+
+      const imageURL = canvas.toDataURL('image/png');
+      const link = document.createElement('a');
+      link.href = imageURL;
+      link.download = 'avatar.png';
+      document.body.appendChild(link);
+      link.dispatchEvent(
+          new MouseEvent('click', { 
+            bubbles: true, 
+            cancelable: true, 
+            view: window 
+          })
+        );
+
+      // Remove link from body
+      document.body.removeChild(link);
+    }
+  }
+}
+</script>

--- a/src/components/save_image.vue
+++ b/src/components/save_image.vue
@@ -10,7 +10,15 @@ import Canvg from 'canvg';
 export default {
   name: 'SaveImage',
   methods: {
+    /**
+     * This method creates an invisible anchor element which is automatically clicked
+     * in order to download the image referenced by the URL passed to the method,
+     *
+     * @param {string} imageURL URL to the image to download
+     */
     downloadImage(imageURL) {
+      // Creating an invisible anchor element and executing the 'click'
+      // method seems to be the standard way of starting a download
       const downloadLink = document.createElement('a');
       downloadLink.href = imageURL;
       downloadLink.download = 'avatar.png';
@@ -23,20 +31,34 @@ export default {
           })
         );
 
-      // Remove link from body
+      // Remove link as final cleanup step
       document.body.removeChild(downloadLink);
     },
+    /**
+     * This method collects all _selected_ svg elements from the avatar
+     * and renders them into a canvas using canvg.
+     * Afterwards the image is provided as download to the user.
+     */
     async saveImage() {
-      const avatarDiv = document.querySelector('#avatar');
-
+      // We need to have a single svg element which is passed to canvg
       let combinedSvg = '<svg width="100%" height="100%">';
 
+      // Helper method to add only those group elements which actually exist
+      // to the combined SVG string
       const addIfAvailable = (element) => {
         if (element !== undefined && element !== null) {
           combinedSvg = combinedSvg + element.outerHTML;
         }
       };
 
+
+      // Select the visible group '<g>' from every option in the avatar
+      // and add it to the combined SVG string.
+      // Note: It would be shorter to use `avatarDiv.querySelectorAll('svg')` and iterate
+      //       over these entries and their '<g>' groups. This does not work here though
+      //       as we need to pay attention to the order of the elements to make sure nothing
+      //       is hidden by another element.
+      const avatarDiv = document.querySelector('#avatar');
       addIfAvailable(avatarDiv.querySelector('#skincolor').querySelector('.show'));
       addIfAvailable(avatarDiv.querySelector('#mouths').querySelector('.show'));
       addIfAvailable(avatarDiv.querySelector('#eyes').querySelector('.show'));
@@ -50,7 +72,8 @@ export default {
 
       combinedSvg = combinedSvg + '</svg>';
 
-      const canvas = document.createElement("canvas"); // create a canvas element
+      // Create an invisible canvas and render the combined SVG onto the canvas.
+      const canvas = document.createElement("canvas");
       canvas.width = 420;
       canvas.height = 420;
       const ctx = canvas.getContext('2d');

--- a/src/components/save_image.vue
+++ b/src/components/save_image.vue
@@ -1,5 +1,7 @@
 <template>
-  <button id="save" @click="saveImage">Download Avatar</button>
+  <div id="save-image">
+    <button type="button" class="save-button" @click="saveImage">Download Avatar</button>
+  </div>
 </template>
 
 <script>

--- a/src/components/save_image.vue
+++ b/src/components/save_image.vue
@@ -10,16 +10,33 @@ import Canvg from 'canvg';
 export default {
   name: 'SaveImage',
   methods: {
+    downloadImage(imageURL) {
+      const downloadLink = document.createElement('a');
+      downloadLink.href = imageURL;
+      downloadLink.download = 'avatar.png';
+      document.body.appendChild(downloadLink);
+      downloadLink.dispatchEvent(
+          new MouseEvent('click', { 
+            bubbles: true, 
+            cancelable: true, 
+            view: window 
+          })
+        );
+
+      // Remove link from body
+      document.body.removeChild(downloadLink);
+    },
     async saveImage() {
       const avatarDiv = document.querySelector('#avatar');
 
       let combinedSvg = '<svg width="100%" height="100%">';
 
-      function addIfAvailable(element) {
+      const addIfAvailable = (element) => {
         if (element !== undefined && element !== null) {
           combinedSvg = combinedSvg + element.outerHTML;
         }
-      }
+      };
+
       addIfAvailable(avatarDiv.querySelector('#skincolor').querySelector('.show'));
       addIfAvailable(avatarDiv.querySelector('#mouths').querySelector('.show'));
       addIfAvailable(avatarDiv.querySelector('#eyes').querySelector('.show'));
@@ -31,9 +48,7 @@ export default {
       addIfAvailable(avatarDiv.querySelector('#hair').querySelector('.show'));
       addIfAvailable(avatarDiv.querySelector('#glasses').querySelector('.show'));
 
-
       combinedSvg = combinedSvg + '</svg>';
-      console.log(combinedSvg);
 
       const canvas = document.createElement("canvas"); // create a canvas element
       canvas.width = 420;
@@ -43,21 +58,7 @@ export default {
 
       await drawn.render();
 
-      const imageURL = canvas.toDataURL('image/png');
-      const link = document.createElement('a');
-      link.href = imageURL;
-      link.download = 'avatar.png';
-      document.body.appendChild(link);
-      link.dispatchEvent(
-          new MouseEvent('click', { 
-            bubbles: true, 
-            cancelable: true, 
-            view: window 
-          })
-        );
-
-      // Remove link from body
-      document.body.removeChild(link);
+      this.downloadImage(canvas.toDataURL('image/png'));
     }
   }
 }

--- a/src/components/save_image.vue
+++ b/src/components/save_image.vue
@@ -77,7 +77,7 @@ export default {
       canvas.width = 420;
       canvas.height = 420;
       const ctx = canvas.getContext('2d');
-      const drawn = Canvg.fromString(ctx, combinedSvg, { ignoreClear: true, ignoreMouse: true });
+      const drawn = Canvg.fromString(ctx, combinedSvg);
 
       await drawn.render();
 


### PR DESCRIPTION
This pull request is meant to solve issue #7 by adding a new UI component: A button which provides the avatar as PNG image for download.

A new dependency was introduced which provides the functionality to convert SVG tags to images: https://github.com/canvg/canvg

With the new button the interface now looks like this:
![AvatarDownloadButtonNoHover](https://user-images.githubusercontent.com/30239051/109433191-673bc300-7a0f-11eb-8226-c6c08b22d5c7.png)

The button looks like this on hover:
![AvatarDownloadButtonHover](https://user-images.githubusercontent.com/30239051/109433211-7f134700-7a0f-11eb-8354-5534594ef17e.png)
